### PR TITLE
Update meta.yaml to fix spelling mistake

### DIFF
--- a/devfiles/swiftTemplate/meta.yaml
+++ b/devfiles/swiftTemplate/meta.yaml
@@ -1,4 +1,4 @@
-displayName: Swift microcservice template
+displayName: Swift microservice template
 description: Template for building a Swift microservice
 tags: ["swift"]
 globalMemoryLimit: 2674Mi


### PR DESCRIPTION
Fix a spelling mistake in the displayName value for the Swift template