### PR TITLE
Rename welcome plugin

### DIFF
--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -13,6 +13,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -14,6 +14,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -14,6 +14,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -14,6 +14,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -14,6 +14,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -13,6 +13,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -13,6 +13,6 @@ components:
   - alias: codewind-theia
     type: chePlugin
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
-  - alias: codewind-welcome
+  - alias: kabanero-welcome
     type: chePlugin
-    id: https://raw.githubusercontent.com/kabanero-io/codewind-che-welcome-plugin/master/plugins/codewind/codewind-welcome/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Sorry for yet another pr, but I was told to rename the welcome plugin to kabanero