### PR TITLE
Point devfiles to v0.2.0 of the Codewind plugins

### DIFF
--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -9,10 +9,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -10,10 +10,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -10,10 +10,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -10,10 +10,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -10,10 +10,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -9,10 +9,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -9,10 +9,10 @@ projects:
 components:
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
   - alias: kabanero-welcome
     type: chePlugin
     id: https://raw.githubusercontent.com/kabanero-io/kabanero-che-welcome-plugin/master/plugins/kabanero/kabanero-welcome/0.0.1/meta.yaml


### PR DESCRIPTION
The Codewind devfiles are now versioned and the upcoming tech preview is using v0.2.0, so this PR updates the devfiles to point to the proper version.