### PR TITLE
Fix #9

### DIFF
--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -1,11 +1,12 @@
 ---
 apiVersion: 1.0.0
 metadata:
-  name: jgoTemplate
+  name: goTemplate
 projects:
-  - source:
-    type: git
-    location: "https://github.com/microclimate-dev2ops/microclimateGoTemplate"
+  - name: goproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/microclimateGoTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -3,10 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: javaMicroProfileTemplate
 projects:
-  - source:
-    type: git
-    language: java
-    location: "https://github.com/microclimate-dev2ops/javaMicroProfileTemplate"
+  - name: javaproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/javaMicroProfileTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -3,10 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: lagomJavaTemplate
 projects:
-  - source:
-    type: git
-    language: java
-    location: "https://github.com/microclimate-dev2ops/lagomJavaTemplate"
+  - name: lagomproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/lagomJavaTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -3,10 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: nodeExpressTemplate
 projects:
-  - source:
-    type: git
-    language: nodejs
-    location: "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
+  - name: nodeproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/nodeExpressTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/openLibertyTemplate/devfile.yaml
+++ b/devfiles/openLibertyTemplate/devfile.yaml
@@ -3,10 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: openLibertyTemplate
 projects:
-  - source:
-    type: git
-    language: java
-    location: "https://github.com/microclimate-dev2ops/openLibertyTemplate"
+  - name: libertyproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/openLibertyTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -3,10 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: Python Template
 projects:
-  - source:
-    type: git
-    language: python
-    location: "https://github.com/microclimate-dev2ops/SVTPythonTemplate"
+  - name: pythonproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/SVTPythonTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -3,9 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: springJavaTemplate
 projects:
-  - source:
-    type: git
-    location: "https://github.com/microclimate-dev2ops/springJavaTemplate"
+  - name: springproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/springJavaTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -3,9 +3,10 @@ apiVersion: 1.0.0
 metadata:
   name: swiftTemplate
 projects:
-  - source:
-    type: git
-    location: "https://github.com/microclimate-dev2ops/swiftTemplate"
+  - name: swiftproject
+    source:
+      type: git
+      location: "https://github.com/microclimate-dev2ops/swiftTemplate"
 components:
   - alias: codewind-sidecar
     type: chePlugin

--- a/index.sh
+++ b/index.sh
@@ -49,7 +49,7 @@ function buildIndex() {
         for field in "${metaInfoFields2[@]}"
         do
            # String value contains quotes, e.g. "str"
-            projects="$(yq r -j "${devfileArray[$count]}" "projects[0].location")"
+            projects="$(yq r -j "${devfileArray[$count]}" "projects[0].source.location")"
             #location="$(yq r -j "$projects" "location")"
            echo "  \"location\":$projects,"
         done


### PR DESCRIPTION
I have tested this fix:

- Regenerated `index.json` with updated devfiles and `index.sh`, the output is same as before
  - (script was already getting `language` from `meta.yaml` rather than the devfile)
- Codewind behaves the same as before when pointed to my branch of `index.json`
- Che can create workspace from the devfiles now (using `f?url=` method)
- Tested with fix for https://github.com/eclipse/che/issues/13634, can see codewind templates show up, and more importantly, the Projects section is correctly populated with the project name and repository location

![image](https://user-images.githubusercontent.com/17596240/61402013-2e81c100-a8a0-11e9-97a6-dac63efdef9d.png)