### PR TITLE
use javascript over nodejs as language for Express template

### DIFF
--- a/devfiles/index.json
+++ b/devfiles/index.json
@@ -26,7 +26,7 @@
 ,{
   "displayName":"Node.js Express",
   "description":"Cloud-ready Node.js Express sample application",
-  "language":"nodejs",
+  "language":"javascript",
   "projectType":"nodejs",
   "location":"https://github.com/microclimate-dev2ops/nodeExpressTemplate",
   "links": {"self":"/devfiles/nodeExpressTemplate/devfile.yaml" }


### PR DESCRIPTION
Resolves https://github.com/eclipse/codewind/issues/784. 

Changes the language for the Express template. Changes will also be proposed for `cwctl` and `pfe` to ensure `language=javascript` is handled in the same way `language=nodejs` is.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>